### PR TITLE
Fixed About screen issue

### DIFF
--- a/src/menu/about.rs
+++ b/src/menu/about.rs
@@ -20,7 +20,7 @@ pub fn show_about(rl: &mut RaylibHandle, thread: &RaylibThread, debug_mode: bool
     let mut displayed_text = String::new();
     let mut char_index = 0;
     let mut last_char_time = Instant::now();
-    let char_delay = Duration::from_millis(30);
+    let char_delay = Duration::from_millis(5);
     let mut should_exit = false;
     let mut input_ready = false;
 


### PR DESCRIPTION
Fixed issue with the 'About' screen popping up. Added a feature of skipping the animation.