### PR TITLE
Automatical creation of `.dir_info`, commands and Saving/restoring design change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ target/
 
 /target
 .DS_Store
-**.dir_info/restore_me**
-**.dir_info/save_me**
+**/.dir_info/restore_me
+**/.dir_info/save_me

--- a/src/commands/cmds.rs
+++ b/src/commands/cmds.rs
@@ -53,7 +53,7 @@ pub fn cmd_manager(
         "ls" => CommandResult::Output(ls(&parts[1..], current_dir, root_dir)),
         "read" => CommandResult::Output(read(&parts[1..], current_dir, root_dir)),
         "copy" => {
-            let msg = copy::copy(&parts[1..], current_dir, root_dir);
+            let msg = copy::copy(&parts[1..], current_dir, root_dir, prompter);
             CommandResult::Output(msg)
         }
         "tap" => {

--- a/src/commands/cmds.rs
+++ b/src/commands/cmds.rs
@@ -1,6 +1,6 @@
 use super::*;
-use std::path::PathBuf;
 use crate::utils::prompt::UserPrompter;
+use std::path::PathBuf;
 
 /// CommandResult enum to represent the result of a command execution
 pub enum CommandResult {
@@ -12,7 +12,12 @@ pub enum CommandResult {
 }
 
 /// Command manager that processes commands and processed to return appropriate outputs
-pub fn cmd_manager(parts: &[&str], current_dir: &PathBuf, root_dir: &PathBuf, prompter: &mut dyn UserPrompter) -> CommandResult {
+pub fn cmd_manager(
+    parts: &[&str],
+    current_dir: &PathBuf,
+    root_dir: &PathBuf,
+    prompter: &mut dyn UserPrompter,
+) -> CommandResult {
     if parts.is_empty() {
         return CommandResult::NotFound;
     }
@@ -26,6 +31,10 @@ pub fn cmd_manager(parts: &[&str], current_dir: &PathBuf, root_dir: &PathBuf, pr
         }
         "ls" => CommandResult::Output(ls(&parts[1..], current_dir, root_dir)),
         "read" => CommandResult::Output(read(&parts[1..], current_dir, root_dir)),
+        "tap" => {
+            let msg = tap(&parts[1..], current_dir, root_dir);
+            CommandResult::Output(msg)
+        }
         "whereami" => CommandResult::Output(whereami(current_dir, root_dir)),
         "help" => {
             if parts.len() > 1 {

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -317,7 +317,7 @@ pub fn copy(
         }
         Err(e) => match &e[..] {
             "help" => HELP_TXT.to_string(),
-            "unknown" => "tap: unknown flag\nTry 'help copy' for more information.".to_string(),
+            "unknown" => "copy: unknown flag\nTry 'help copy' for more information.".to_string(),
             _ => "Error parsing arguments. Try 'help copy' for more information.".to_string(),
         },
     }

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -1,0 +1,315 @@
+use super::argparser::ArgParser;
+use super::cmds::normalize_path;
+use super::display_relative_path;
+use crate::utils::log;
+use crate::utils::valid_sekai::create_dir_info;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub const HELP_TXT: &str = r#"
+Usage: copy [OPTIONS] <SOURCE> <DESTINATION>
+
+Copy or move files/directories. By default, performs a copy operation.
+Options:
+    -x, --cut       Move instead of copy (cut/paste)
+    -r, --recursive Copy directories recursively
+    -f, --force     Overwrite existing files
+    -h, --help      Display this help message
+
+Examples:
+- copy file.txt new_file.txt         # Copy file
+- copy -r dir/ new_dir/              # Recursive directory copy
+- copy -x old.txt new.txt            # Move (cut/paste) file
+- copy -x -r old_dir/ new_location/    # Move directory recursively
+- copy -f existing_file.txt new_file.txt  # Force overwrite existing file
+"#;
+
+/// Validates paths for copy/move operations
+fn validate_paths(
+    src: &Path,
+    dest: &Path,
+    current_dir: &PathBuf,
+    root_dir: &Path,
+) -> Result<(PathBuf, PathBuf), String> {
+    let src_path = current_dir.join(src);
+    let dest_path = current_dir.join(dest);
+
+    let src_normalized = normalize_path(&src_path);
+    let dest_normalized = normalize_path(&dest_path);
+
+    log::log_debug(
+        "copy",
+        &format!(
+            "Source: {}, Destination: {}",
+            src_normalized.display(),
+            dest_normalized.display()
+        ),
+    );
+
+    // Verify paths are within root directory
+    if !src_normalized.starts_with(root_dir) {
+        return Err(format!(
+            "copy: {}: Cannot operate outside of root directory",
+            src.display()
+        ));
+    }
+
+    if !dest_normalized.starts_with(root_dir) {
+        return Err(format!(
+            "copy: {}: Cannot operate outside of root directory",
+            dest.display()
+        ));
+    }
+
+    // Check if source exists
+    if !src_normalized.exists() {
+        return Err(format!(
+            "copy: {}: No such file or directory",
+            src.display()
+        ));
+    }
+
+    Ok((src_normalized, dest_normalized))
+}
+
+/// Copies a file from source to destination
+fn copy_file(src: &Path, dest: &Path, force: bool) -> io::Result<()> {
+    if dest.exists() {
+        if !force {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "Destination file exists (use -f to overwrite)",
+            ));
+        }
+        fs::remove_file(dest)?;
+    }
+    fs::copy(src, dest)?;
+    Ok(())
+}
+
+/// Recursively copies a directory
+fn copy_directory(src: &Path, dest: &Path, root_dir: &Path, force: bool) -> io::Result<String> {
+    // Create destination directory (without .dir_info initially)
+    if dest.exists() {
+        if !force {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "Destination directory exists (use -f to overwrite)",
+            ));
+        }
+        fs::remove_dir_all(dest)?;
+    }
+    fs::create_dir_all(dest)?;
+
+    // Copy contents except .dir_info
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let entry_path = entry.path();
+        let entry_name = entry.file_name();
+
+        // Skip .dir_info
+        if entry_name == ".dir_info" {
+            continue;
+        }
+
+        let new_path = dest.join(entry_name);
+
+        if entry_path.is_dir() {
+            copy_directory(&entry_path, &new_path, root_dir, force)?;
+        } else {
+            copy_file(&entry_path, &new_path, force)?;
+        }
+    }
+
+    // Create new .dir_info in destination
+    if !create_dir_info(&dest.to_path_buf()) {
+        return Err(io::Error::other(format!(
+            "Failed to create .dir_info in {}",
+            display_relative_path(dest, root_dir)
+        )));
+    }
+
+    Ok(format!(
+        "Copied directory: {} → {}",
+        display_relative_path(src, root_dir),
+        display_relative_path(dest, root_dir)
+    ))
+}
+
+/// Moves a file or directory (cut/paste)
+fn move_item(
+    src: &Path,
+    dest: &Path,
+    root_dir: &Path,
+    recursive: bool,
+    force: bool,
+) -> io::Result<String> {
+    // Prevent moving .dir_info directly
+    if src.ends_with(".dir_info") {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Cannot move .dir_info directly",
+        ));
+    }
+
+    if src.is_dir() {
+        if !recursive {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Use -r for directories",
+            ));
+        }
+
+        // Prepare destination
+        if dest.exists() && !force {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "Use -f to overwrite",
+            ));
+        }
+        fs::create_dir_all(dest)?;
+
+        // Move contents except .dir_info
+        fs::read_dir(src)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name() != ".dir_info")
+            .try_for_each(|e| {
+                let new_path = dest.join(e.file_name());
+                fs::rename(e.path(), &new_path).or_else(|_| {
+                    if e.path().is_dir() {
+                        copy_directory(&e.path(), &new_path, root_dir, force)?;
+                    } else {
+                        copy_file(&e.path(), &new_path, force)?;
+                    }
+                    fs::remove_dir_all(&e.path()).or_else(|_| fs::remove_file(&e.path()))
+                })
+            })?;
+
+        fs::remove_dir(src)?;
+        if !create_dir_info(&dest.to_path_buf()) {
+            return Err(io::Error::other(format!(
+                "Failed to create .dir_info in {}",
+                display_relative_path(dest, root_dir)
+            )));
+        }
+    } else {
+        // Handle file move
+        if dest.exists() && !force {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "Use -f to overwrite",
+            ));
+        }
+        fs::rename(src, dest).or_else(|_| {
+            copy_file(src, dest, force)?;
+            fs::remove_file(src)
+        })?;
+    }
+
+    Ok(format!(
+        "Moved {} → {}",
+        display_relative_path(src, root_dir),
+        display_relative_path(dest, root_dir)
+    ))
+}
+
+/// Helper to delete directory contents except .dir_info
+fn delete_directory_contents(path: &Path) -> io::Result<()> {
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let entry_path = entry.path();
+        let entry_name = entry.file_name();
+
+        // Skip .dir_info
+        if entry_name == ".dir_info" {
+            continue;
+        }
+
+        if entry_path.is_dir() {
+            fs::remove_dir_all(&entry_path)?;
+        } else {
+            fs::remove_file(&entry_path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Main copy command function
+pub fn copy(args: &[&str], current_dir: &PathBuf, root_dir: &Path) -> String {
+    let valid_flags = vec![
+        "-x",
+        "--cut",
+        "-r",
+        "--recursive",
+        "-f",
+        "--force",
+        "-h",
+        "--help",
+    ];
+    let mut parser = ArgParser::new(&valid_flags);
+
+    let args_string: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+
+    log::log_debug(
+        "copy",
+        &format!(
+            "Parsing arguments: {:?}, Current Directory: {}",
+            args_string,
+            current_dir.display(),
+        ),
+    );
+
+    match parser.parse(&args_string) {
+        Ok(_) => {
+            // Get source and destination arguments
+            let paths: Vec<&str> = args
+                .iter()
+                .filter(|&&arg| !valid_flags.contains(&arg))
+                .copied()
+                .collect();
+
+            if paths.len() != 2 {
+                return "copy: Requires exactly two paths (source and destination)".to_string();
+            }
+
+            // handle source and destination paths, and flags
+            let (src, dest) = (Path::new(paths[0]), Path::new(paths[1]));
+            let cut = args.contains(&"-x") || args.contains(&"--cut");
+            let recursive = args.contains(&"-r") || args.contains(&"--recursive");
+            let force = args.contains(&"-f") || args.contains(&"--force");
+
+            // Validate paths and perform operations
+            match validate_paths(src, dest, current_dir, root_dir) {
+                Ok((src_path, dest_path)) => {
+                    let result = if cut {
+                        move_item(&src_path, &dest_path, root_dir, recursive, force)
+                    } else if src_path.is_dir() && !recursive {
+                        Err(io::Error::other("Cannot copy directory without -r flag"))
+                    } else if src_path.is_dir() {
+                        copy_directory(&src_path, &dest_path, root_dir, force)
+                    } else {
+                        copy_file(&src_path, &dest_path, force).map(|_| {
+                            format!(
+                                "Copied {} to {}",
+                                display_relative_path(&src_path, root_dir),
+                                display_relative_path(&dest_path, root_dir)
+                            )
+                        })
+                    };
+
+                    match result {
+                        Ok(msg) => msg,
+                        Err(e) => format!("copy: {}", e),
+                    }
+                }
+                Err(e) => e,
+            }
+        }
+        Err(e) => match &e[..] {
+            "help" => HELP_TXT.to_string(),
+            "unknown" => "tap: unknown flag\nTry 'help copy' for more information.".to_string(),
+            _ => "Error parsing arguments. Try 'help copy' for more information.".to_string(),
+        },
+    }
+}

--- a/src/commands/del.rs
+++ b/src/commands/del.rs
@@ -1,0 +1,192 @@
+use super::argparser::ArgParser;
+use super::cmds::normalize_path;
+use super::display_relative_path;
+use crate::utils::log;
+use crate::utils::prompt::UserPrompter;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const HELP_TXT: &str = r#"
+Usage: del [OPTIONS] [PATH]
+
+Delete file or directory in the current directory. By default, deletes a file.
+Options:
+    -d, --dir       Delete a directory (must be empty unless -f is used)
+    -f, --force     Force delete (recursively delete directories)
+    -h, --help      Display this help message
+
+Examples:
+- del file.txt
+- del -d empty_directory
+- del -f directory_with_contents
+"#;
+
+/// Delete a file at the given path
+pub fn delete_file(path: &Path, root_dir: &Path) -> String {
+    if !path.exists() {
+        return format!(
+            "del: {}: No such file",
+            display_relative_path(path, root_dir)
+        );
+    }
+
+    if path.is_dir() {
+        return format!(
+            "del: {}: Is a directory (use -d flag)",
+            display_relative_path(path, root_dir)
+        );
+    }
+
+    match std::fs::remove_file(path) {
+        Ok(_) => format!("Deleted file: {}", display_relative_path(path, root_dir)),
+        Err(e) => format!("del: {}: {}", display_relative_path(path, root_dir), e),
+    }
+}
+
+/// Delete a directory at the given path
+pub fn delete_directory(path: &Path, root_dir: &Path, force: bool) -> String {
+    if !path.exists() {
+        return format!(
+            "del: {}: No such directory",
+            display_relative_path(path, root_dir)
+        );
+    }
+    if !path.is_dir() {
+        return format!(
+            "del: {}: Not a directory",
+            display_relative_path(path, root_dir)
+        );
+    }
+
+    // Check if directory only contains .dir_info
+    let only_has_dir_info = || {
+        if let Ok(entries) = fs::read_dir(path) {
+            entries.count() == 1 && path.join(".dir_info").exists()
+        } else {
+            false
+        }
+    };
+
+    // Handle special case for .dir_info
+    if only_has_dir_info() {
+        let _ = fs::remove_dir_all(path.join(".dir_info"));
+        return match fs::remove_dir(path) {
+            Ok(_) => format!(
+                "Deleted directory: {}",
+                display_relative_path(path, root_dir)
+            ),
+            Err(e) => format!("del: {}: {}", display_relative_path(path, root_dir), e),
+        };
+    }
+
+    // Normal deletion
+    let result = if force {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_dir(path)
+    };
+
+    match result {
+        Ok(_) => format!(
+            "Deleted directory: {}",
+            display_relative_path(path, root_dir)
+        ),
+        Err(e) => format!("del: {}: {}", display_relative_path(path, root_dir), e),
+    }
+}
+
+/// Checks the validity of the deletion path
+fn validate_deletion_path(
+    path: &Path,
+    current_dir: &PathBuf,
+    root_dir: &Path,
+) -> Result<PathBuf, String> {
+    let mut full_path = current_dir.join(path);
+    full_path = normalize_path(&full_path);
+
+    log::log_debug("del", &format!("Path to delete: {}", full_path.display()));
+
+    // Verify the path is within root directory
+    if !full_path.starts_with(root_dir) {
+        log::log_warning("del", "Attempted to delete outside of root directory");
+        return Err(format!(
+            "del: {}: Cannot delete outside of root directory",
+            path.display()
+        ));
+    }
+
+    // Check if path exists
+    if !full_path.exists() {
+        log::log_warning("del", "Path does not exist");
+        return Err(format!(
+            "del: {}: No such file or directory",
+            path.display()
+        ));
+    }
+
+    Ok(full_path)
+}
+
+/// Main delete command function
+pub fn del(
+    args: &[&str],
+    current_dir: &PathBuf,
+    root_dir: &Path,
+    prompter: &mut dyn UserPrompter,
+) -> String {
+    let mut parser = ArgParser::new(&["-d", "--dir", "-f", "--force"]);
+
+    let args_string: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+
+    log::log_debug(
+        "del",
+        &format!(
+            "Parsing arguments: {:?}, Current Directory: {}",
+            args_string,
+            current_dir.display(),
+        ),
+    );
+
+    match parser.parse(&args_string) {
+        Ok(_) => {
+            let destination = args
+                .iter()
+                .find(|&&arg| !arg.starts_with('-'))
+                .unwrap_or(&"");
+
+            if destination.is_empty() {
+                return "del: No destination specified. Use 'del --help' for usage.".to_string();
+            }
+            if destination.contains(".dir_info") {
+                return "del: Cannot delete .dir_info file or directory. Operation Not Allowed."
+                    .to_string();
+            }
+
+            if !prompter.confirm(&format!(
+                "Are you sure you want to delete '{}'? This action cannot be undone.",
+                destination
+            )) {
+                return "Deletion cancelled by user.".to_string();
+            }
+
+            let destination_path = Path::new(destination);
+            match validate_deletion_path(destination_path, current_dir, root_dir) {
+                Ok(full_path) => {
+                    let force = args.contains(&"-f") || args.contains(&"--force");
+
+                    if args.contains(&"-d") || args.contains(&"--dir") || full_path.is_dir() {
+                        delete_directory(&full_path, root_dir, force)
+                    } else {
+                        delete_file(&full_path, root_dir)
+                    }
+                }
+                Err(e) => e,
+            }
+        }
+        Err(e) => match &e[..] {
+            "help" => HELP_TXT.to_string(),
+            "unknown" => "del: unknown flag\nTry 'help del' for more information.".to_string(),
+            _ => "Error parsing arguments. Try 'help del' for more information.".to_string(),
+        },
+    }
+}

--- a/src/commands/exit.rs
+++ b/src/commands/exit.rs
@@ -1,0 +1,14 @@
+use crate::utils::prompt::UserPrompter;
+
+pub fn exit(prompter: &mut dyn UserPrompter) -> (bool, String) {
+    if !prompter.confirm(
+        "Are you sure you want to exit? Make sure you have saved your progress before exiting.",
+    ) {
+        (false, "Exit cancelled by user.".to_string())
+    } else {
+        // Perform any necessary cleanup here
+        // For example, saving state, closing files, etc.
+        // This is a placeholder for any cleanup logic you might need.
+        (true, "Exiting the application. Goodbye!".to_string())
+    }
+}

--- a/src/commands/go.rs
+++ b/src/commands/go.rs
@@ -158,7 +158,7 @@ pub fn go(args: &[&str], current_dir: &PathBuf, root_dir: &Path) -> (PathBuf, St
             "help" => (current_dir.clone(), HELP_TXT.to_string()),
             "unknown" => (
                 current_dir.clone(),
-                "ls: unknown flag\nTry 'help go' for more information.".to_string(),
+                "go: unknown flag\nTry 'help go' for more information.".to_string(),
             ),
             _ => (
                 current_dir.clone(),

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -30,6 +30,9 @@ Welcome to DBD Deemak Help. You can use the following commands:
 - go <directory>: Changes the current directory to the specified directory.
 - ls: Lists the objects and places you can go to in the current directory.
 - read <file>: Reads the specified file.
+- copy <source> <destination>: Copies a file/directory from source to destination.
+- tap <file>: Creates new file/directory with the specified name.
+- del <file>: Deletes the specified file/directory.
 - whereami: Displays where you are.
 - help: Displays this help message.
 - exit: Exits the program.

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -7,14 +7,16 @@ pub fn get_command_help(command: &str) -> Option<&'static str> {
         "ls" => Some(ls::HELP_TXT),
         "help" => Some("help [command]: Displays help for the specified command."),
         "read" => Some(read::HELP_TXT),
+        "copy" => Some(copy::HELP_TXT),
         "tap" => Some(tap::HELP_TXT),
+        "del" => Some(del::HELP_TXT),
         "whereami" => Some("whereami: Displays the current directory."),
         "whoami" => Some("whoami: Displays who you are."),
         "exit" => Some("exit: Exits the program."),
         "clear" => Some("clear: Clears the screen."),
         "restore" => Some(restore::HELP_TEXT),
         "save" => Some(save::HELP_TEXT),
-        _ => None,
+        _ => Some("No help available for this command. Check if the command is valid."),
     }
 }
 

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -7,6 +7,7 @@ pub fn get_command_help(command: &str) -> Option<&'static str> {
         "ls" => Some(ls::HELP_TXT),
         "help" => Some("help [command]: Displays help for the specified command."),
         "read" => Some(read::HELP_TXT),
+        "tap" => Some(tap::HELP_TXT),
         "whereami" => Some("whereami: Displays the current directory."),
         "whoami" => Some("whoami: Displays who you are."),
         "exit" => Some("exit: Exits the program."),

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -83,10 +83,12 @@ pub fn ls(args: &[&str], current_dir: &Path, root_dir: &Path) -> String {
                 }
             }
 
+            // Use (none) for no files or directories
             if directories.is_empty() {
                 directories = "   (none)\n".to_string();
             }
 
+            // Displaying files and directories
             // Format output with relative path header
             format!(
                 "\nObjects:\n{files}\nFrom inside here, you can go to:\n{directories}",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,8 +13,17 @@ pub use ls::ls;
 mod tap;
 pub use tap::tap;
 
+mod del;
+pub use del::del;
+
 mod go;
 pub use go::go;
+
+mod copy;
+pub use copy::copy;
+
+mod exit;
+pub use exit::exit;
 
 mod whereami;
 pub use whereami::{display_relative_path, whereami};

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,6 +10,9 @@ pub use help::{get_command_help, help};
 mod ls;
 pub use ls::ls;
 
+mod tap;
+pub use tap::tap;
+
 mod go;
 pub use go::go;
 

--- a/src/commands/tap.rs
+++ b/src/commands/tap.rs
@@ -1,0 +1,167 @@
+use super::argparser::ArgParser;
+use super::display_relative_path;
+use crate::utils::log;
+use crate::utils::valid_sekai::create_dir_info;
+use std::path::{Path, PathBuf};
+
+pub const HELP_TXT: &str = r#"
+Usage: tap [OPTIONS] [NAME]
+
+Create file or directory in the current directory. By default, creates a file.
+Options:
+    -d, --dir       Create a directory
+    -h, --help      Display this help message
+
+Examples:
+- tap new_file
+- tap -d new_directory
+- tap new_dir/    # usage of trailing slash to create a directory
+"#;
+
+pub fn create_file(destination: &str, current_dir: &PathBuf, root_dir: &Path) -> String {
+    let new_path: &PathBuf = &current_dir.join(destination);
+
+    // Check if the path already exists
+    if new_path.exists() {
+        return format!("tap: {}: File or directory already exists", destination);
+    }
+
+    // Create the file or directory
+    match std::fs::File::create(new_path) {
+        Ok(_) => format!(
+            "Created file: {}",
+            display_relative_path(new_path, root_dir)
+        ),
+        Err(e) => format!("tap: {}: {}", destination, e),
+    }
+}
+
+pub fn create_directory(destination: &str, current_dir: &PathBuf, root_dir: &Path) -> String {
+    let new_path: &PathBuf = &current_dir.join(destination);
+
+    // Check if the path already exists
+    if new_path.exists() {
+        return format!(
+            "tap: {}: Directory already exists",
+            display_relative_path(new_path, root_dir)
+        );
+    }
+
+    // Create the directory
+    match std::fs::create_dir(new_path) {
+        Ok(_) => {
+            // create .dir_info automatically
+            if !create_dir_info(new_path) {
+                return format!(
+                    "tap: Failed to create .dir_info: {}",
+                    display_relative_path(new_path, root_dir)
+                );
+            }
+            format!(
+                "Created directory: {}",
+                display_relative_path(new_path, root_dir)
+            )
+        }
+        Err(e) => format!("tap: {}: {}", display_relative_path(new_path, root_dir), e),
+    }
+}
+
+/// Checks the validity of the destination path based on root_dir and current_dir.
+fn handle_destination(
+    destination: &Path,
+    current_dir: &PathBuf,
+    root_dir: &Path,
+) -> Result<PathBuf, String> {
+    // Get absolute path by joining with current_dir and normalizing
+    let mut new_path = current_dir.join(destination);
+    new_path = normalize_path(&new_path);
+    log::log_debug("tap", &format!("New Path to tap: {}", new_path.display()));
+
+    // Verify the path is within root directory
+    if !new_path.starts_with(root_dir) {
+        log::log_warning("tap", "Attempted to create outside of root directory");
+        return Err(format!(
+            "tap: {}: Cannot create outside of root directory",
+            destination.display()
+        ));
+    }
+    // Check if path already exists
+    if new_path.exists() {
+        log::log_warning("tap", "File or directory already exists");
+        return Err(format!(
+            "tap: {}: File or directory already exists",
+            destination.display()
+        ));
+    }
+    log::log_info("tap", &format!("Valid path: {}", new_path.display()));
+    Ok(new_path)
+}
+
+/// Normalizes a path by removing `.` and `..` components
+fn normalize_path(path: &Path) -> PathBuf {
+    let components = path.components();
+    let mut normalized = PathBuf::new();
+
+    for component in components {
+        match component {
+            std::path::Component::ParentDir => {
+                if !normalized.pop() {
+                    // If we can't go up further, keep the parent dir
+                    normalized.push("..");
+                }
+            }
+            std::path::Component::CurDir => {}
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+// Check if the destination is within the root directory
+pub fn tap(args: &[&str], current_dir: &PathBuf, root_dir: &Path) -> String {
+    let mut parser = ArgParser::new(&[]);
+
+    let args_string: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+
+    log::log_debug(
+        "tap",
+        &format!(
+            "Parsing arguments: {:?}, Current Directory: {}",
+            args_string,
+            current_dir.display(),
+        ),
+    );
+    match parser.parse(&args_string) {
+        Ok(_) => {
+            let mut destination = args
+                .iter()
+                .find(|&&arg| !arg.starts_with('-'))
+                .unwrap_or(&"") as &str;
+
+            if destination.is_empty() {
+                return "tap: No destination specified. Use 'tap --help' for usage.".to_string();
+            }
+            // handle destination path
+            let destination_path = Path::new(destination);
+            if handle_destination(destination_path, current_dir, root_dir).is_err() {
+                // the error string will be printed
+                return handle_destination(destination_path, current_dir, root_dir).unwrap_err();
+            } else {
+                // This is relative valid path
+                destination = destination_path.to_str().unwrap();
+            }
+
+            if args.contains(&"-d") || args.contains(&"--dir") {
+                destination = destination.trim_end_matches('/');
+                // Create a directory
+                create_directory(destination, current_dir, root_dir)
+            } else if destination.ends_with('/') {
+                create_directory(destination.trim_end_matches('/'), current_dir, root_dir)
+            } else {
+                // Create a file
+                create_file(destination, current_dir, root_dir)
+            }
+        }
+        Err(e) => format!("tap: Invalid arguments: {}", e),
+    }
+}

--- a/src/gui_shell.rs
+++ b/src/gui_shell.rs
@@ -88,11 +88,11 @@ impl ShellScreen {
             root_dir: root_dir.clone(),
             current_dir: root_dir, // Both point to same path initially
             font,
+            font_size,
             window_width,
             window_height,
             char_width,
             term_split_ratio: 2.0 / 3.0,
-            font_size,
             scroll_offset: 0,
             active_prompt: None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,14 +4,13 @@ mod server;
 mod utils;
 use deemak::DEBUG_MODE;
 use deemak::menu;
-use once_cell::sync::OnceCell;
+use raylib::RaylibHandle;
+use raylib::RaylibThread;
 use raylib::ffi::{SetConfigFlags, SetTargetFPS};
 use raylib::prelude::get_monitor_width;
-use std::path::PathBuf;
+use utils::globals::WORLD_DIR;
 use utils::{debug_mode, find_root, globals, log, restore_comp, valid_sekai};
-use valid_sekai::validate_sekai;
-
-static WORLD_DIR: OnceCell<PathBuf> = OnceCell::new();
+use valid_sekai::validate_or_create_sekai;
 
 pub const HELP_TXT: &str = r#"
 Usage: deemak <sekai_directory> [--debug] [--web]
@@ -37,7 +36,7 @@ fn main() {
             "SEKAI",
             &format!("Sekai directory provided: {:?}", sekai_path),
         );
-        if !validate_sekai(&sekai_path) {
+        if !validate_or_create_sekai(&sekai_path) {
             log::log_error(
                 "SEKAI",
                 &format!("sekai directory does not exist: {:?}", sekai_path),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,8 @@ mod server;
 mod utils;
 use deemak::DEBUG_MODE;
 use deemak::menu;
-use raylib::RaylibHandle;
-use raylib::RaylibThread;
 use raylib::ffi::{SetConfigFlags, SetTargetFPS};
 use raylib::prelude::get_monitor_width;
-use utils::globals::WORLD_DIR;
 use utils::{debug_mode, find_root, globals, log, restore_comp, valid_sekai};
 use valid_sekai::validate_or_create_sekai;
 
@@ -36,6 +33,7 @@ fn main() {
             "SEKAI",
             &format!("Sekai directory provided: {:?}", sekai_path),
         );
+        // If not valid, create .dir_info for each of them.
         if !validate_or_create_sekai(&sekai_path) {
             log::log_error(
                 "SEKAI",
@@ -46,8 +44,11 @@ fn main() {
         } else {
             log::log_info("SEKAI", &format!("Sekai is Valid {:?}", sekai_path));
 
-            // Create the restore file if it does/doesn't exist, because anyways that world only
-            // will be played, so make the restore file of that
+            let root_dir =
+                find_root::find_home(&sekai_path).expect("Failed to find root directory");
+
+            // Create the restore file if it doesn't exist, since it is required for restoring. The
+            // progress will be saved as `save_me` and will be recreated every run.
             log::log_info(
                 "SEKAI",
                 &format!(
@@ -55,12 +56,35 @@ fn main() {
                     sekai_path.join(".dir_info/restore_me")
                 ),
             );
-            let root_dir =
-                find_root::find_home(&sekai_path).expect("Failed to find root directory");
-            if let Err(e) = restore_comp::backup_sekai("restore", &root_dir) {
-                log::log_error("SEKAI", &format!("Failed to create restore file: {}", e));
-                eprintln!("Error: Failed to create restore file: {}\nContinuing...", e);
-                return;
+            // restore_me should be made initially if it doesnt exist, else it will not be created
+            match restore_comp::backup_sekai("restore", &root_dir) {
+                Err(e) => {
+                    log::log_error("SEKAI", &format!("Failed to create restore file: {}", e));
+                    eprintln!("Error: Failed to create restore file: {}\nContinuing...", e);
+                    return;
+                }
+                Ok(msg) => {
+                    log::log_info("SEKAI", &msg);
+                }
+            }
+
+            // save_me should be made initially if it doesnt exist, it will be created every run
+            log::log_info(
+                "SEKAI",
+                &format!(
+                    "Creating save file for Sekai at {:?}",
+                    sekai_path.join(".dir_info/save_me")
+                ),
+            );
+            match restore_comp::backup_sekai("save", &root_dir) {
+                Err(e) => {
+                    log::log_error("SEKAI", &format!("Failed to create save file: {}", e));
+                    eprintln!("Error: Failed to create save file: {}\nContinuing...", e);
+                    return;
+                }
+                Ok(msg) => {
+                    log::log_info("SEKAI", &msg);
+                }
             }
         }
         Some(sekai_path)
@@ -72,19 +96,44 @@ fn main() {
         return;
     };
 
+    // If `save_me` already exists, then the sekai will be restored from it.
+    match restore_comp::restore_sekai("save", &sekai_dir.clone().unwrap()) {
+        Err(err) => {
+            log::log_error(
+                "SEKAI",
+                &format!("Failed to restore Sekai from save file: {}", err),
+            );
+            eprintln!(
+                "Error: Failed to restore Sekai from save file at {:?}\nContinuing...",
+                sekai_dir
+            );
+        }
+        Ok(_) => {
+            log::log_info("SEKAI", "Sekai restored successfully from save file");
+        }
+    }
+
     globals::WORLD_DIR
         .set(sekai_dir.clone().unwrap())
         .expect("Failed to set world dir");
 
+    // NOTE: All Directory operations and variables settings should be done before this point.
+    //
     // We have 2 modes, the web and the raylib gui. The web argument runs it on the web, else
     // raylib gui is set by default.
+    //
+    // NOTE: #############    SERVER USAGE    #############
+    //
+    // Initialize the server if --web argument is provided
     if args.iter().any(|arg| arg == "--web") {
         log::log_info("Application", "Running in web mode");
         // server::launch_web(sekai_dir.clone().unwrap());
-        server::server();
+        let _ = server::server();
         return;
     }
 
+    // NOTE: #############    RAYLIB GUI USAGE    #############
+    //
     // Initialize Raylib window
     unsafe {
         SetConfigFlags(4);

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,9 +37,15 @@ fn main() {
         if !validate_or_create_sekai(&sekai_path) {
             log::log_error(
                 "SEKAI",
-                &format!("sekai directory does not exist: {:?}", sekai_path),
+                &format!(
+                    "Sekai directory is not valid even after creating default `.dir_info`. Sekai: {:?}",
+                    sekai_path
+                ),
             );
-            eprintln!("Error: sekai directory does not exist: {:?}", sekai_path);
+            eprintln!(
+                "Error: Sekai directory is not valid even after creating default `.dir_info`. Please check the sekai validity. Sekai: {:?}",
+                sekai_path
+            );
             return;
         } else {
             log::log_info("SEKAI", &format!("Sekai is Valid {:?}", sekai_path));

--- a/src/utils/info_reader.rs
+++ b/src/utils/info_reader.rs
@@ -59,7 +59,6 @@ impl Info {
 }
 
 pub fn read_validate_info(info_path: &PathBuf) -> Result<Info, InfoError> {
-    check_dir_info_exists(info_path);
 
     if !info_path.exists() {
         return Err(InfoError::NotFound(info_path.display().to_string()));

--- a/src/utils/info_reader.rs
+++ b/src/utils/info_reader.rs
@@ -1,10 +1,11 @@
-use serde::Deserialize;
+use super::valid_sekai::check_dir_info_exists;
+use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::Path;
+use std::path::PathBuf;
 use thiserror::Error;
 
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)] // Rejects unexpected fields
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Info {
     #[serde(rename = "location")]
     pub location: String,
@@ -24,70 +25,52 @@ pub enum InfoError {
     ValidationError(String),
 }
 
-/// Implements methods for the `Info` struct.
 impl Info {
-    /// Validates the struct contents
+    /// Creates default Info values for a path
+    pub fn default_for_path(path: &PathBuf) -> Self {
+        let dir_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown");
+
+        Info {
+            location: if path.ends_with("sekai") {
+                "home".to_string()
+            } else {
+                dir_name.to_string()
+            },
+            about: format!("You are in '{}'. Look around and explore!", dir_name),
+        }
+    }
+
     pub fn validate(&self) -> Result<(), InfoError> {
         if self.location.trim().is_empty() {
             return Err(InfoError::ValidationError(
                 "Location cannot be empty".to_string(),
             ));
         }
-
         if self.about.trim().is_empty() {
             return Err(InfoError::ValidationError(
                 "About cannot be empty".to_string(),
             ));
         }
-
         Ok(())
     }
 }
 
-/// Reads and validates the info.json file and returns an `Info` struct.
-pub fn read_validate_info(info_path: &Path) -> Result<Info, InfoError> {
-    // File existence check
+pub fn read_validate_info(info_path: &PathBuf) -> Result<Info, InfoError> {
+    check_dir_info_exists(info_path);
+
     if !info_path.exists() {
         return Err(InfoError::NotFound(info_path.display().to_string()));
     }
 
-    // Read and parse
     let contents = fs::read_to_string(info_path)?;
     let mut info: Info = serde_json::from_str(&contents)?;
 
-    // Clean data
     info.about = info.about.trim_matches('"').trim().to_string();
     info.location = info.location.trim().to_string();
 
-    // Validate
     info.validate()?;
-
     Ok(info)
-}
-
-/// Validates a JSON string against the expected schema for `Info`.
-pub fn validate_json_schema(json_str: &str) -> Result<(), InfoError> {
-    let value: serde_json::Value = serde_json::from_str(json_str)?;
-
-    match (value.get("location"), value.get("about")) {
-        (Some(loc), Some(about)) => {
-            if !loc.is_string() {
-                return Err(InfoError::ValidationError(
-                    "location must be a string".to_string(),
-                ));
-            }
-            if !about.is_string() {
-                return Err(InfoError::ValidationError(
-                    "about must be a string".to_string(),
-                ));
-            }
-        }
-        _ => {
-            return Err(InfoError::ValidationError(
-                "Missing required fields: 'location' and 'about'".to_string(),
-            ));
-        }
-    }
-
-    Ok(())
 }

--- a/src/utils/log.rs
+++ b/src/utils/log.rs
@@ -27,7 +27,7 @@ pub fn log_debug(feature: &str, message: &str) {
 ///     log_info("info_reader", "Successfully read info from file: ...");
 pub fn log_info(feature: &str, message: &str) {
     if debug_mode() {
-        println!("[INFO] {} :: {}", feature, message);
+        println!("\x1b[32m[INFO]\x1b[0m {} :: {}", feature, message);
     }
 }
 

--- a/src/utils/valid_sekai.rs
+++ b/src/utils/valid_sekai.rs
@@ -31,7 +31,16 @@ pub fn create_dir_info(dir: &PathBuf) -> bool {
     // Write as proper JSON file
     match std::fs::write(
         &info_path,
-        serde_json::to_string_pretty(&default_info).unwrap(),
+        match serde_json::to_string_pretty(&default_info) {
+            Ok(json) => json,
+            Err(e) => {
+                log::log_error(
+                    "SEKAI",
+                    &format!("Failed to serialize default info for {}: {}", dir.display(), e),
+                );
+                return false;
+            }
+        },
     ) {
         Ok(_) => {
             log::log_info(

--- a/src/utils/valid_sekai.rs
+++ b/src/utils/valid_sekai.rs
@@ -1,34 +1,63 @@
 use super::{log, read_validate_info};
-use std::path::Path;
+use std::path::PathBuf;
 
-/// Validates an info.json file at the given path
-fn validate_info_file(info_path: &Path) -> bool {
-    match read_validate_info(info_path) {
-        Ok(info) => {
-            if let Err(e) = info.validate() {
-                log::log_error(
-                    "SEKAI",
-                    &format!("Invalid info.json at {}: {}", info_path.display(), e),
-                );
-                false
-            } else {
-                true
-            }
+/// Creates properly formatted .dir_info with valid JSON info.json
+pub fn create_dir_info(dir: &PathBuf) -> bool {
+    // Skip if this is a .dir_info directory
+    if dir.file_name().and_then(|n| n.to_str()) == Some(".dir_info") {
+        return true;
+    }
+
+    let dir_info = dir.join(".dir_info");
+    let info_path = dir_info.join("info.json");
+
+    // Skip if already exists
+    if info_path.exists() {
+        return true;
+    }
+
+    // Create directory if needed
+    if let Err(e) = std::fs::create_dir_all(&dir_info) {
+        log::log_error(
+            "SEKAI",
+            &format!("Failed to create .dir_info in {}: {}", dir.display(), e),
+        );
+        return false;
+    }
+
+    // Get default values from Info struct
+    let default_info = super::info_reader::Info::default_for_path(dir);
+
+    // Write as proper JSON file
+    match std::fs::write(
+        &info_path,
+        serde_json::to_string_pretty(&default_info).unwrap(),
+    ) {
+        Ok(_) => {
+            log::log_info(
+                "SEKAI",
+                &format!("Created valid info.json for: {}", dir.display()),
+            );
+            true
         }
         Err(e) => {
             log::log_error(
                 "SEKAI",
-                &format!("Failed to read info.json at {}: {}", info_path.display(), e),
+                &format!("Failed to create info.json in {}: {}", dir.display(), e),
             );
             false
         }
     }
 }
 
-/// Checks if .dir_info/info.json exists and is valid
-fn check_dir_info_exists(dir: &Path) -> bool {
-    let info_path = dir.join(".dir_info/info.json");
+/// Checks if .dir_info/info.json exists and is valid (updated for PathBuf)
+pub fn check_dir_info_exists(dir: &PathBuf) -> bool {
+    // Skip .dir_info directories
+    if dir.file_name().and_then(|n| n.to_str()) == Some(".dir_info") {
+        return true;
+    }
 
+    let info_path = dir.join(".dir_info/info.json");
     if !info_path.exists() {
         log::log_warning(
             "SEKAI",
@@ -36,14 +65,26 @@ fn check_dir_info_exists(dir: &Path) -> bool {
         );
         return false;
     }
-
     validate_info_file(&info_path)
 }
 
-/// Recursively checks directory structure
-fn check_subdirectories(path: &Path) -> bool {
-    let mut all_valid = true;
+/// Validates an info.json file at the given path (updated for PathBuf)
+fn validate_info_file(info_path: &PathBuf) -> bool {
+    match read_validate_info(info_path) {
+        Ok(info) => info.validate().is_ok(),
+        Err(e) => {
+            log::log_error(
+                "SEKAI",
+                &format!("Invalid info.json at {}: {}", info_path.display(), e),
+            );
+            false
+        }
+    }
+}
 
+/// Recursively checks directory structure (updated for PathBuf)
+fn check_subdirectories(path: &PathBuf) -> bool {
+    let mut all_valid = true;
     let entries = match std::fs::read_dir(path) {
         Ok(entries) => entries,
         Err(e) => {
@@ -57,35 +98,31 @@ fn check_subdirectories(path: &Path) -> bool {
 
     for entry in entries.filter_map(|e| e.ok()) {
         let entry_path = entry.path();
-
         if entry_path.is_dir() {
             let dir_name = entry_path
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or("");
 
-            // Skip recursing into .dir_info directory
+            // Skip .dir_info directories
             if dir_name == ".dir_info" {
                 continue;
             }
 
-            // All directories (including dot-directories) must have .dir_info/info.json
-            if !check_dir_info_exists(&entry_path) {
+            let entry_path_buf = PathBuf::from(entry_path);
+            if !check_dir_info_exists(&entry_path_buf) {
                 all_valid = false;
             }
-
-            // Recursively check other subdirectories
-            if !check_subdirectories(&entry_path) {
+            if !check_subdirectories(&entry_path_buf) {
                 all_valid = false;
             }
         }
     }
-
     all_valid
 }
 
-/// Main validation function
-pub fn validate_sekai(sekai_path: &Path) -> bool {
+/// Main validation function with auto-creation
+pub fn validate_or_create_sekai(sekai_path: &PathBuf) -> bool {
     if !sekai_path.exists() {
         log::log_error(
             "SEKAI",
@@ -107,19 +144,44 @@ pub fn validate_sekai(sekai_path: &Path) -> bool {
         &format!("Validating directory: {}", sekai_path.display()),
     );
 
-    // First check the root directory's .dir_info
-    if !check_dir_info_exists(sekai_path) {
-        return false;
-    }
+    // First validate
+    let mut all_valid = check_dir_info_exists(sekai_path);
+    all_valid &= check_subdirectories(sekai_path);
 
-    let all_valid = check_subdirectories(sekai_path);
+    // If invalid, attempt to fix
+    if !all_valid {
+        log::log_info("SEKAI", "Attempting to create missing .dir_info...");
+        all_valid = true; // Reset and check again after creation
+
+        // Create for root if missing
+        if !sekai_path.join(".dir_info/info.json").exists() {
+            all_valid &= create_dir_info(sekai_path);
+        }
+
+        // Create for subdirectories if missing
+        if let Ok(entries) = std::fs::read_dir(sekai_path) {
+            for entry in entries.filter_map(|e| e.ok()) {
+                let path = PathBuf::from(entry.path());
+                if path.is_dir() && path.file_name().and_then(|n| n.to_str()) != Some(".dir_info") {
+                    if !path.join(".dir_info/info.json").exists() {
+                        all_valid &= create_dir_info(&path);
+                    }
+                }
+            }
+        }
+
+        // Re-validate after creation attempts
+        if all_valid {
+            all_valid = check_dir_info_exists(sekai_path) && check_subdirectories(sekai_path);
+        }
+    }
 
     if all_valid {
         log::log_info("SEKAI", "Directory structure is valid");
     } else {
         log::log_error(
             "SEKAI",
-            "Directory structure is invalid - missing or invalid .dir_info/info.json files",
+            "Directory structure could not be validated/created",
         );
     }
 

--- a/src/utils/valid_sekai.rs
+++ b/src/utils/valid_sekai.rs
@@ -53,7 +53,7 @@ pub fn create_dir_info(dir: &PathBuf) -> bool {
 /// Checks if .dir_info/info.json exists and is valid (updated for PathBuf)
 pub fn check_dir_info_exists(dir: &PathBuf) -> bool {
     // Skip .dir_info directories
-    if dir.file_name().and_then(|n| n.to_str()) == Some(".dir_info") {
+    if dir.components().any(|c| c.as_os_str() == ".dir_info") {
         return true;
     }
 

--- a/src/utils/valid_sekai.rs
+++ b/src/utils/valid_sekai.rs
@@ -118,7 +118,7 @@ fn check_subdirectories(path: &PathBuf) -> bool {
                 continue;
             }
 
-            let entry_path_buf = PathBuf::from(entry_path);
+            let entry_path_buf = entry_path;
             if !check_dir_info_exists(&entry_path_buf) {
                 all_valid = false;
             }
@@ -170,11 +170,12 @@ pub fn validate_or_create_sekai(sekai_path: &PathBuf) -> bool {
         // Create for subdirectories if missing
         if let Ok(entries) = std::fs::read_dir(sekai_path) {
             for entry in entries.filter_map(|e| e.ok()) {
-                let path = PathBuf::from(entry.path());
-                if path.is_dir() && path.file_name().and_then(|n| n.to_str()) != Some(".dir_info") {
-                    if !path.join(".dir_info/info.json").exists() {
-                        all_valid &= create_dir_info(&path);
-                    }
+                let path = entry.path();
+                if path.is_dir()
+                    && path.file_name().and_then(|n| n.to_str()) != Some(".dir_info")
+                    && !path.join(".dir_info/info.json").exists()
+                {
+                    all_valid &= create_dir_info(&path);
                 }
             }
         }


### PR DESCRIPTION
This PR implements the following commands

## New commands 
- [x] exit
- [x] tap (creating files and directories)
- [x] del (deleting files and dirs)
- [x] copy (copy paste and move)

## Restore and Saving 

From this PR, the `restore_me` file is as a snapshot of the whole sekai, which will not be rewritten again. It's like a restarts from scratch. Whenever deemak runs, it creates `save_me` which is where you start from, (`save_me` may not be == `restore_me` in this case.
Then user must save every time he exits and he will start from there. This is all taken care automatically.

## Dir Info
When you create or move a directory, a dummy `.dir_info` is made for it, which default `about` and `location` as directory name. And if you manually (outside deemak) add a directory, it will create a default `.dir_info` for this too.
The validity and info reader has been improved and made more robust.

